### PR TITLE
fix(linux): enhance firewall checks for server and TxPort

### DIFF
--- a/src/FirewallManager.cs
+++ b/src/FirewallManager.cs
@@ -144,7 +144,10 @@ public class FirewallManager {
 #if WINDOWS
         return true;
 #elif LINUX
-        return DefaultBlockForServerLinux(server.Port);
+        if(!DefaultBlockForServerLinux(server.Port)) return false;
+        if(server.TxPort.HasValue && !DefaultBlockForServerLinux(server.TxPort.Value)) return false;
+
+        return true;
 #endif
         return false;
     }


### PR DESCRIPTION
By default, if there is a TxAdmin port, it is also blocked directly on the IP address.
The current problem is that the TxAdmin port with the agent remains accessible.